### PR TITLE
First cut at check digit computation using layering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.DS_Store
+*/.DS_Store
+.DS_Store
+src/.DS_Store
+target/
+dependency-reduced-pom.xml
+.idea
+/.metadata/

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,17 @@
+name := "dfdl-checkDigit"
+
+organization := "com.owlcyberdefense"
+
+version := "1.0.0"
+
+scalaVersion := "2.12.14"
+
+libraryDependencies ++= Seq(
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.1.0" % "test",
+  "com.novocode" % "junit-interface" % "0.11" % "test",
+  "junit" % "junit" % "4.12" % "test",
+)
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
+
+crossPaths := false

--- a/src/main/resources/com/owlcyberdefense/misc/xsd/checkDigitLayer.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/misc/xsd/checkDigitLayer.dfdl.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:cd="urn:checkDigit"
+  targetNamespace="urn:checkDigit"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+
+      <dfdl:format ref="cd:GeneralFormat" />
+
+      <dfdl:defineVariable name="checkDigit" type="unsignedInt"/>
+
+      <dfdl:defineFormat name="checkDigitExplicit">
+        <!-- up to an explicit length limit, only digits are totaled. Other characters
+             are ignored --> 
+        <dfdl:format layerTransform="checkDigitExplicit" layerLengthKind="explicit"/>
+      </dfdl:defineFormat>
+
+      <dfdl:defineFormat name="checkDigitImplicit">
+        <!-- up to but not including the first non-digit character --> 
+        <dfdl:format layerTransform="checkDigitExplicit" layerLengthKind="implicit"/>
+      </dfdl:defineFormat>
+     
+    </appinfo>
+  </annotation>
+
+</schema>

--- a/src/test/resources/com/owlcyberdefense/misc/TestCheckDigit.tdml
+++ b/src/test/resources/com/owlcyberdefense/misc/TestCheckDigit.tdml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<tdml:testSuite suiteName="Gpssps" description="Gpssps tests"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions" 
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ex="http://example.com"
+  xmlns:cd="urn:checkDigit"
+  defaultRoundTrip="onePass">
+
+  <tdml:defineSchema name="checkDigit1" elementFormDefault="unqualified" useDefaultNamespace="false"
+    xmlns="http://www.w3.org/2001/XMLSchema">
+
+    <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <import 
+      namespace="urn:checkDigit"
+      schemaLocation="com/owlcyberdefense/misc/xsd/checkDigitLayer.dfdl.xsd"/>
+
+
+    <element name="r">
+       <complexType>
+          <sequence>
+            <annotation>
+              <appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:newVariableInstance ref="cd:checkDigit"/>
+              </appinfo>
+            </annotation>
+            <sequence>
+              <sequence dfdl:ref="cd:checkDigitExplicit" dfdl:layerLength="5">
+                <element name="value" type="ex:u5"/>
+              </sequence>
+              <element name="cd" type="ex:u1"
+                       dfdl:outputValueCalc='{ $cd:checkDigit }'/> 
+              <annotation><appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:assert 
+                    failureType="recoverableError" 
+                    test='{ cd eq $cd:checkDigit }'
+                    message='{ fn:concat("Incorrect check digit: ", cd, ". Should be: ", $cd:checkDigit, "."}'/>
+              </appinfo></annotation>
+            </sequence>
+          </sequence>
+       </complexType>
+    </element>
+               
+
+     <simpleType name="u5" dfdl:length="5">
+       <restriction base="ex:fixedInt"/>
+     </simpleType>
+
+     <simpleType name="u1" dfdl:length="1">
+       <restriction base="ex:fixedInt"/>
+     </simpleType>
+
+     <simpleType name="fixedInt" dfdl:lengthKind="explicit" 
+       dfdl:textNumberPattern="########0">
+       <xs:restriction base="unsignedInt"/>
+     </simpleType>
+         
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="test_checkDigit_01" root="r" model="checkDigit1">
+    <tdml:document>12345:5</tdml:document>
+    <tdml:infoset>
+      <ex:r>
+       <value>12345</value>
+       <cd>5</cd>
+      </ex:r>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/src/test/scala/com/owlcyberdefense/misc/TestCheckDigit.scala
+++ b/src/test/scala/com/owlcyberdefense/misc/TestCheckDigit.scala
@@ -1,0 +1,23 @@
+package com.owlcyberdefense.misc
+
+import org.junit.AfterClass
+import org.junit.Test
+
+import org.apache.daffodil.tdml.Runner
+
+object TestCheckDigit {
+  lazy val runner = Runner("/com/owlcyberdefense/misc/", "TestCheckDigit.tdml")
+
+  @AfterClass def shutDown {
+    runner.reset
+  }
+}
+
+class TestCheckDigit {
+
+  import TestCheckDigit._
+
+  @Test def test_checkDigit_01(): Unit = {
+    runner.runOneTest("test_checkDigit_01")
+  }
+}


### PR DESCRIPTION
A DFDL schema showing how a check-digit can be verified on parse and recomputed on unparse.

The check digit is the result of taking all digits 0-9 of the layer data, adding them together, and taking only the least-significant digit of the resulting sum. 

So for 10:22:18.234 The sum is 23, so the check-digit is 3. 

